### PR TITLE
chore: update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       - id: terraform_tflint
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.43.0
+    rev: v0.47.0
     hooks:
       - id: markdownlint
         args: ['--fix']
@@ -42,7 +42,7 @@ repos:
       - id: actionlint
 
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v3.6.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]


### PR DESCRIPTION
Automated update of pre-commit hook versions.

**Changes:**
- markdownlint-cli: v0.43.0 → v0.47.0
- conventional-pre-commit: v3.6.0 → v4.4.0

Please review the changes and merge if tests pass.