### PR TITLE
fix: use Terraform outputs for dynamic validation

### DIFF
--- a/.github/workflows/terraform-cicd.yml
+++ b/.github/workflows/terraform-cicd.yml
@@ -78,9 +78,17 @@ jobs:
         run: |
           echo "🔍 Validating deployment..."
 
+          # Get Terraform outputs
+          cd terraform/scps
+          DEV_SCP_ID=$(terraform output -raw dev_scp_id 2>/dev/null || echo "")
+          ORG_ID=$(terraform output -raw organization_id 2>/dev/null || echo "")
+
           # Validate Organization
           echo "Checking organization..."
-          ORG_ID=$(aws organizations describe-organization --query 'Organization.Id' --output text)
+          if [ -z "$ORG_ID" ]; then
+            echo "❌ Could not get organization ID from Terraform output"
+            exit 1
+          fi
           if [ "$ORG_ID" != "$EXPECTED_ORG_ID" ]; then
             echo "❌ Organization ID mismatch"
             exit 1
@@ -98,16 +106,20 @@ jobs:
 
           # Validate Dev SCP exists
           echo "Checking Dev SCP policy..."
-          DEV_SCP=$(aws organizations list-policies --filter SERVICE_CONTROL_POLICY --query "Policies[?Name==\`dev-scp\`].Id" --output text)
-          if [ -z "$DEV_SCP" ]; then
-            echo "❌ Dev SCP policy not found"
+          if [ -z "$DEV_SCP_ID" ]; then
+            echo "❌ Could not get Dev SCP ID from Terraform output"
             exit 1
           fi
-          echo "✅ Dev SCP policy exists: ${DEV_SCP}"
+          SCP_EXISTS=$(aws organizations describe-policy --policy-id "$DEV_SCP_ID" --query 'Policy.PolicySummary.Id' --output text 2>/dev/null || echo "")
+          if [ -z "$SCP_EXISTS" ]; then
+            echo "❌ Dev SCP policy not found in AWS"
+            exit 1
+          fi
+          echo "✅ Dev SCP policy exists: ${DEV_SCP_ID}"
 
           # Validate SCP attached to Dev OU
           echo "Checking SCP attachment..."
-          ATTACHED=$(aws organizations list-policies-for-target --target-id "$EXPECTED_DEV_OU" --filter SERVICE_CONTROL_POLICY --query "Policies[?Name==\`dev-scp\`].Id" --output text)
+          ATTACHED=$(aws organizations list-policies-for-target --target-id "$EXPECTED_DEV_OU" --filter SERVICE_CONTROL_POLICY --query "Policies[?Id==\`${DEV_SCP_ID}\`].Id" --output text)
           if [ -z "$ATTACHED" ]; then
             echo "❌ Dev SCP not attached to Dev OU"
             exit 1
@@ -116,7 +128,7 @@ jobs:
 
           # Validate SCP content (check for key restrictions)
           echo "Validating SCP content..."
-          POLICY_CONTENT=$(aws organizations describe-policy --policy-id "${DEV_SCP}" --query 'Policy.Content' --output text)
+          POLICY_CONTENT=$(aws organizations describe-policy --policy-id "${DEV_SCP_ID}" --query 'Policy.Content' --output text)
           if ! echo "$POLICY_CONTENT" | grep -q "us-east-1"; then
             echo "❌ Region restriction not found in policy"
             exit 1
@@ -128,7 +140,7 @@ jobs:
           echo "📊 Deployment Summary:"
           echo "  - Organization: ${ORG_ID}"
           echo "  - Dev OU: ${EXPECTED_DEV_OU}"
-          echo "  - Dev SCP: ${DEV_SCP}"
+          echo "  - Dev SCP: ${DEV_SCP_ID}"
           echo "  - Status: Deployed and validated"
 
   terraform-destroy:

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,9 @@
+# Deploy Dev SCP
+
+This branch deploys the Dev OU Service Control Policy with cost controls and security guardrails.
+
+## Changes
+
+- Enables SCPs on organization
+- Creates Dev SCP policy with restrictions
+- Attaches SCP to Dev OU


### PR DESCRIPTION
## Problem
Post-deployment validation was hardcoded to look for policy name `dev-scp` but Terraform creates it as `DevEnvironmentRestrictions`.

## Solution
- Use `terraform output` to get SCP ID dynamically
- Validate using policy ID instead of name lookup
- More reliable and works with any policy name

## Testing
Will be tested in the apply workflow