### PR TITLE
refactor: use data source for organization

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -1,0 +1,32 @@
+# Prerequisites
+
+## Enable Service Control Policies
+
+Before deploying SCPs with Terraform, you must enable the SCP policy type
+on your AWS Organization. This is a one-time operation.
+
+### Enable SCPs (One Command)
+
+```bash
+aws organizations enable-policy-type \
+  --root-id $(aws organizations list-roots \
+    --query 'Roots[0].Id' --output text) \
+  --policy-type SERVICE_CONTROL_POLICY
+```
+
+### Verify SCPs are Enabled
+
+```bash
+aws organizations list-roots \
+  --query 'Roots[0].PolicyTypes[?Type==`SERVICE_CONTROL_POLICY`].Status' \
+  --output text
+```
+
+Expected output: `ENABLED`
+
+### Why This is Required
+
+The `aws_organizations_organization` Terraform resource cannot be safely
+destroyed without removing all member accounts first. By enabling SCPs
+manually and using a data source in Terraform, we avoid this issue while
+still managing policies declaratively.

--- a/terraform/scps/README.md
+++ b/terraform/scps/README.md
@@ -1,5 +1,0 @@
-# State unlocked
-
-# Trigger
-
-Trigger CI/CD

--- a/terraform/scps/main.tf
+++ b/terraform/scps/main.tf
@@ -1,15 +1,9 @@
-# Manage existing AWS Organization and enable SCPs
-resource "aws_organizations_organization" "org" {
-  feature_set = "ALL"
-
-  enabled_policy_types = [
-    "SERVICE_CONTROL_POLICY"
-  ]
-}
+# Reference existing AWS Organization (read-only)
+# Prerequisite: Enable SCPs first (see docs/prerequisites.md)
+data "aws_organizations_organization" "org" {}
 
 # Dev OU Service Control Policy
 resource "aws_organizations_policy" "dev_scp" {
-  depends_on  = [aws_organizations_organization.org]
   name        = "DevEnvironmentRestrictions"
   description = "Cost controls and security guardrails for Dev OU"
   type        = "SERVICE_CONTROL_POLICY"

--- a/terraform/scps/outputs.tf
+++ b/terraform/scps/outputs.tf
@@ -1,6 +1,6 @@
 output "organization_id" {
   description = "AWS Organization ID"
-  value       = aws_organizations_organization.org.id
+  value       = data.aws_organizations_organization.org.id
 }
 
 output "dev_scp_id" {


### PR DESCRIPTION
## Problem
Running `terraform destroy` fails because it tries to delete the organization, which requires removing all member accounts first.

## Solution
- Change `aws_organizations_organization` from resource to data source
- Update outputs to reference data source
- Document SCP enablement as manual prerequisite in `docs/prerequisites.md`
- Remove `depends_on` from policy resource
- SCPs are already enabled from previous deployment

## Benefits
- Terraform can now safely destroy policies without touching the org
- Cleaner separation: manual one-time setup vs managed policies
- No workarounds or state manipulation needed

## Testing
Will test with plan/apply/destroy workflow