### PR TITLE
feat: add SSO protection SCP and scope IAM role

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -5,11 +5,12 @@ config {
 plugin "terraform" {
   enabled = true
   source  = "github.com/terraform-linters/tflint-ruleset-terraform"
+  version = "0.12.0"
   preset  = "all"
 }
 
 plugin "aws" {
   enabled = true
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
-  version = "0.37.1"
+  version = "0.45.0"
 }

--- a/docs/github-oidc-setup.md
+++ b/docs/github-oidc-setup.md
@@ -73,31 +73,69 @@ aws iam create-role \
 aws iam get-role --role-name GitHubActions-<PROJECT_NAME>
 ```
 
-## Step 3: Attach AWS Managed Policy for Organizations
+## Step 3: Create Scoped Policy for SCP Management
+
+> **WARNING**: Do NOT use `AWSOrganizationsFullAccess`.
+> It grants `DisableAWSServiceAccess` which can break
+> IAM Identity Center (SSO).
 
 ```bash
-aws iam attach-role-policy \
+aws iam put-role-policy \
   --role-name GitHubActions-<PROJECT_NAME> \
-  --policy-arn arn:aws:iam::aws:policy/AWSOrganizationsFullAccess
+  --policy-name SCPManagement \
+  --policy-document '{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Sid": "AllowSCPManagement",
+        "Effect": "Allow",
+        "Action": [
+          "organizations:CreatePolicy",
+          "organizations:UpdatePolicy",
+          "organizations:DeletePolicy",
+          "organizations:DescribePolicy",
+          "organizations:ListPolicies",
+          "organizations:ListPoliciesForTarget",
+          "organizations:AttachPolicy",
+          "organizations:DetachPolicy",
+          "organizations:ListTargetsForPolicy",
+          "organizations:DescribeOrganization",
+          "organizations:ListRoots",
+          "organizations:ListAccounts"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Sid": "DenyDangerousActions",
+        "Effect": "Deny",
+        "Action": [
+          "organizations:DisableAWSServiceAccess",
+          "organizations:EnableAWSServiceAccess",
+          "organizations:DeleteOrganization",
+          "organizations:LeaveOrganization",
+          "organizations:RemoveAccountFromOrganization"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }'
 ```
 
-**Verify attachment:**
+**Verify policy:**
 
 ```bash
-aws iam list-attached-role-policies --role-name GitHubActions-<PROJECT_NAME>
+aws iam get-role-policy \
+  --role-name GitHubActions-<PROJECT_NAME> \
+  --policy-name SCPManagement
 ```
 
-Expected output:
+If you previously attached `AWSOrganizationsFullAccess`, remove it:
 
-```json
-{
-    "AttachedPolicies": [
-        {
-            "PolicyName": "AWSOrganizationsFullAccess",
-            "PolicyArn": "arn:aws:iam::aws:policy/AWSOrganizationsFullAccess"
-        }
-    ]
-}
+```bash
+aws iam detach-role-policy \
+  --role-name GitHubActions-<PROJECT_NAME> \
+  --policy-arn \
+    arn:aws:iam::aws:policy/AWSOrganizationsFullAccess
 ```
 
 ## Step 4: Add Inline Policy for Terraform State Access
@@ -181,14 +219,14 @@ The complete setup consists of:
 
 2. **IAM Role:** `GitHubActions-<PROJECT_NAME>`
    - Trust policy: Allows GitHub Actions from specific repository
-   - Managed policy: `AWSOrganizationsFullAccess`
+   - Inline policy: `SCPManagement` (scoped Organizations access)
    - Inline policy: `TerraformStateAccess` (S3 bucket access)
 
 3. **GitHub Secret:** `AWS_ROLE_ARN`
 
 ## Security Best Practices
 
-1. **Least Privilege**: Uses AWS managed policy for Organizations + minimal S3 access
+1. **Least Privilege**: Scoped SCP management + explicit deny on dangerous actions
 2. **Repository Restriction**: Trust policy limits access to specific repository
 3. **No Long-lived Credentials**: OIDC tokens expire automatically
 4. **Audit Trail**: All actions logged in CloudTrail

--- a/terraform/scps/import.tf
+++ b/terraform/scps/import.tf
@@ -1,5 +1,0 @@
-# Import existing AWS Organization
-import {
-  to = aws_organizations_organization.org
-  id = var.organization_id
-}

--- a/terraform/scps/main.tf
+++ b/terraform/scps/main.tf
@@ -106,3 +106,33 @@ resource "aws_organizations_policy_attachment" "dev_scp_attachment" {
   policy_id = aws_organizations_policy.dev_scp.id
   target_id = var.dev_ou_id
 }
+
+# Protect SSO trusted access from being disabled
+# Applied to root to protect the entire organization
+resource "aws_organizations_policy" "protect_sso" {
+  name        = "ProtectSSOTrustedAccess"
+  description = "Prevent disabling IAM Identity Center trusted access"
+  type        = "SERVICE_CONTROL_POLICY"
+
+  content = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "DenyDisableSSO"
+        Effect   = "Deny"
+        Action   = "organizations:DisableAWSServiceAccess"
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "organizations:ServicePrincipal" = "sso.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_organizations_policy_attachment" "protect_sso_root" {
+  policy_id = aws_organizations_policy.protect_sso.id
+  target_id = data.aws_organizations_organization.org.roots[0].id
+}

--- a/terraform/scps/variables.tf
+++ b/terraform/scps/variables.tf
@@ -1,8 +1,3 @@
-variable "organization_id" {
-  description = "AWS Organization ID"
-  type        = string
-}
-
 variable "dev_ou_id" {
   description = "Dev OU ID"
   type        = string


### PR DESCRIPTION
## Problem
Terraform with `AWSOrganizationsFullAccess` called `DisableAWSServiceAccess` for `sso.amazonaws.com`, breaking IAM Identity Center for ~1 hour.

## Solution

### 1. SSO Protection SCP
- New `ProtectSSOTrustedAccess` policy attached to org root
- Denies `organizations:DisableAWSServiceAccess` for `sso.amazonaws.com`
- Prevents any principal from disabling SSO trusted access

### 2. Scoped IAM Role
- Replaced `AWSOrganizationsFullAccess` with custom `SCPManagement` inline policy
- Only allows SCP-related actions (create, update, delete, attach, detach)
- Explicit deny on dangerous actions (DisableAWSServiceAccess, DeleteOrganization, etc.)

### 3. Cleanup
- Removed stale `import.tf` (old org resource import)
- Removed unused `organization_id` variable
- Fixed tflint AWS ruleset version to 0.45.0

## Root Cause Reference
See `docs/github-oidc-setup.md` for updated IAM role setup