### PR TITLE
fix: add ListAWSServiceAccessForOrganization to scoped IAM policy

### DIFF
--- a/docs/github-oidc-setup.md
+++ b/docs/github-oidc-setup.md
@@ -101,7 +101,8 @@ aws iam put-role-policy \
           "organizations:ListTargetsForPolicy",
           "organizations:DescribeOrganization",
           "organizations:ListRoots",
-          "organizations:ListAccounts"
+          "organizations:ListAccounts",
+          "organizations:ListAWSServiceAccessForOrganization"
         ],
         "Resource": "*"
       },


### PR DESCRIPTION
The `data.aws_organizations_organization` data source calls `ListAWSServiceAccessForOrganization` to read service access principals. This was missing from the scoped IAM policy.

IAM role already updated on AWS. This PR updates the docs to match.