### PR TITLE
fix: add tag permissions to scoped IAM policy docs

### DIFF
--- a/docs/github-oidc-setup.md
+++ b/docs/github-oidc-setup.md
@@ -102,7 +102,10 @@ aws iam put-role-policy \
           "organizations:DescribeOrganization",
           "organizations:ListRoots",
           "organizations:ListAccounts",
-          "organizations:ListAWSServiceAccessForOrganization"
+          "organizations:ListAWSServiceAccessForOrganization",
+          "organizations:ListTagsForResource",
+          "organizations:TagResource",
+          "organizations:UntagResource"
         ],
         "Resource": "*"
       },


### PR DESCRIPTION
Terraform AWS provider calls `ListTagsForResource` after creating/reading organizations resources. Added `TagResource` and `UntagResource` for future tag management.

IAM role already updated on AWS. This PR syncs the docs.