### PR TITLE
feat: add dynamic run name to CI/CD workflow

### DIFF
--- a/.github/workflows/terraform-cicd.yml
+++ b/.github/workflows/terraform-cicd.yml
@@ -1,4 +1,10 @@
 name: Terraform CI/CD
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch'
+    && format('Terraform {0}', inputs.action)
+    || github.event_name == 'push'
+    && format('Terraform plan (push: {0})', github.event.head_commit.message)
+    || format('Terraform plan (PR #{0})', github.event.pull_request.number) }}
 
 on:
   pull_request:


### PR DESCRIPTION
Shows `Terraform plan`, `Terraform apply`, or `Terraform destroy` in the run list instead of the generic `Terraform CI/CD` name. Also includes push commit message and PR number for non-dispatch triggers.