### PR TITLE
fix: align PR and pre-commit workflows with composite action pattern

### DIFF
--- a/.github/actions/lint-and-security-composite/action.yml
+++ b/.github/actions/lint-and-security-composite/action.yml
@@ -1,0 +1,43 @@
+name: 'Lint and Security Scan Composite Action'
+description: 'Runs Terraform linting and security scanning on PRs'
+
+inputs:
+  terraform_version:
+    description: 'Terraform version to use'
+    required: false
+    default: '1.14.5'
+  working_directory:
+    description: 'Directory containing Terraform configuration'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: ${{ inputs.terraform_version }}
+
+    - name: Terraform Format Check
+      shell: bash
+      run: terraform fmt -check -recursive
+      working-directory: ${{ inputs.working_directory }}
+
+    - name: TFLint Setup
+      uses: terraform-linters/setup-tflint@v6
+      with:
+        tflint_version: latest
+
+    - name: Run TFLint
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      run: |
+        tflint --init
+        tflint --recursive
+
+    - name: Checkov Security Scan
+      uses: bridgecrewio/checkov-action@v12
+      with:
+        directory: ${{ inputs.working_directory }}
+        framework: terraform
+        soft_fail: false

--- a/.github/actions/update-pre-commit-composite/action.yml
+++ b/.github/actions/update-pre-commit-composite/action.yml
@@ -1,0 +1,36 @@
+name: 'Update Pre-commit Hooks Composite Action'
+description: 'Updates pre-commit hook versions and creates a PR'
+
+inputs:
+  github_token:
+    description: 'GitHub token for creating PRs'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.x'
+
+    - name: Install pre-commit
+      shell: bash
+      run: pip install pre-commit
+
+    - name: Update hooks
+      shell: bash
+      run: pre-commit autoupdate
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v8
+      with:
+        token: ${{ inputs.github_token }}
+        commit-message: 'chore: update pre-commit hooks'
+        title: 'chore: update pre-commit hook versions'
+        body: |
+          Automated update of pre-commit hook versions.
+
+          Please review the changes and merge if tests pass.
+        branch: chore/update-pre-commit-hooks
+        delete-branch: true

--- a/.github/workflows/terraform-pr.yml
+++ b/.github/workflows/terraform-pr.yml
@@ -1,4 +1,6 @@
 name: Terraform PR Checks
+run-name: >-
+  Terraform PR checks (PR #${{ github.event.pull_request.number }})
 
 on:
   pull_request:
@@ -6,6 +8,8 @@ on:
     paths:
       - 'terraform/**'
       - '.github/workflows/terraform-pr.yml'
+      - '.github/actions/lint-and-security-composite/**'
+      - '.github/actions/terraform-composite/**'
 
 permissions:
   id-token: write
@@ -20,39 +24,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+      - name: Run Lint and Security
+        uses: ./.github/actions/lint-and-security-composite
         with:
-          terraform_version: 1.14.5
-
-      - name: Terraform Format Check
-        run: terraform fmt -check -recursive
-        working-directory: terraform
-
-      - name: TFLint Setup
-        uses: terraform-linters/setup-tflint@v6
-        with:
-          tflint_version: latest
-
-      - name: Run TFLint
-        run: |
-          tflint --init
-          tflint --recursive
-        working-directory: terraform
-
-      - name: Checkov Security Scan
-        uses: bridgecrewio/checkov-action@v12
-        with:
-          directory: terraform
-          framework: terraform
-          soft_fail: false
+          working_directory: terraform/scps
 
   terraform-plan:
     name: Terraform Plan
     runs-on: ubuntu-latest
     needs: lint-and-security
     env:
-      TF_VAR_organization_id: ${{ vars.TF_VAR_organization_id }}
       TF_VAR_dev_ou_id: ${{ vars.TF_VAR_dev_ou_id }}
       TF_VAR_aws_region: ${{ vars.TF_VAR_aws_region }}
     steps:

--- a/.github/workflows/update-pre-commit-hooks.yml
+++ b/.github/workflows/update-pre-commit-hooks.yml
@@ -2,8 +2,8 @@ name: Update Pre-commit Hooks
 
 on:
   schedule:
-    - cron: '0 0 * * 0'  # Weekly on Sunday at midnight UTC
-  workflow_dispatch:  # Manual trigger
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -17,26 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Update Hooks
+        uses: ./.github/actions/update-pre-commit-composite
         with:
-          python-version: '3.x'
-
-      - name: Install pre-commit
-        run: pip install pre-commit
-
-      - name: Update hooks
-        run: pre-commit autoupdate
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: 'chore: update pre-commit hooks'
-          title: 'Update pre-commit hook versions'
-          body: |
-            Automated update of pre-commit hook versions.
-
-            Please review the changes and merge if tests pass.
-          branch: update-pre-commit-hooks
-          delete-branch: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

- Extract lint/security inline logic to `lint-and-security-composite` action
- Extract pre-commit update inline logic to `update-pre-commit-composite` action
- Remove stale `TF_VAR_organization_id` reference from PR workflow
- Add dynamic `run-name` to PR workflow
- Add composite action paths to PR trigger