### PR TITLE
fix: correct Bedrock model ID for inference profile

### DIFF
--- a/.github/scripts/ai-deployment-analysis.sh
+++ b/.github/scripts/ai-deployment-analysis.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 
 echo "🤖 Running AI deployment analysis..."
 
-BEDROCK_MODEL_ID="${BEDROCK_MODEL_ID:-us.anthropic.claude-sonnet-4-6-v1}"
+BEDROCK_MODEL_ID="${BEDROCK_MODEL_ID:-us.anthropic.claude-sonnet-4-6}"
 
 # Gather all SCP policy content (truncated to 50K total)
 POLICIES=""

--- a/.github/workflows/terraform-cicd.yml
+++ b/.github/workflows/terraform-cicd.yml
@@ -94,7 +94,7 @@ jobs:
         env:
           WORKING_DIRECTORY: terraform/scps
           VALIDATION_LOG: ${{ steps.validation.outputs.validation_log }}
-          BEDROCK_MODEL_ID: us.anthropic.claude-sonnet-4-6-v1
+          BEDROCK_MODEL_ID: us.anthropic.claude-sonnet-4-6
         run: ${{ github.workspace }}/.github/scripts/ai-deployment-analysis.sh
 
   terraform-destroy:


### PR DESCRIPTION
## Summary
- Fix invalid model ID `us.anthropic.claude-sonnet-4-6-v1` to `us.anthropic.claude-sonnet-4-6`
- The `-v1` suffix doesn't exist as an inference profile, causing `ValidationException` on every deploy

## Test plan
- [x] Verified `us.anthropic.claude-sonnet-4-6` is ACTIVE via `aws bedrock list-inference-profiles`
- [x] Tested locally with correct model ID — Bedrock invocation succeeded
- [x] Both runs #23080862060 and #23081461174 failed AI step with this exact error