### PR TITLE
fix: allow all regions in Bedrock IAM policy for cross-region inference

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -184,10 +184,13 @@ jobs:
           persist-credentials: false
 
       - name: Install Vale
+        env:
+          VALE_VERSION: "3.13.1"
         run: |
-          VALE_VERSION="3.13.1"
+          tmpdir="$(mktemp -d)"
           wget -q "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz"
-          tar xzf "vale_${VALE_VERSION}_Linux_64-bit.tar.gz" -C /usr/local/bin vale
+          tar xzf "vale_${VALE_VERSION}_Linux_64-bit.tar.gz" -C "$tmpdir" vale
+          sudo mv "$tmpdir/vale" /usr/local/bin/vale
 
       - name: Run Vale
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,6 +79,7 @@ repos:
         entry: bash -c 'vale sync --no-progress 2>/dev/null; vale "$@"' --
         language: system
         types: [markdown]
+        exclude: ^terraform/scps/README\.md$
 
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.11

--- a/docs/github-oidc-setup.md
+++ b/docs/github-oidc-setup.md
@@ -195,8 +195,8 @@ aws iam put-role-policy \
           "bedrock:InvokeModel"
         ],
         "Resource": [
-          "arn:aws:bedrock:us-east-1::foundation-model/anthropic.*",
-          "arn:aws:bedrock:us-east-1:*:inference-profile/us.anthropic.*"
+          "arn:aws:bedrock:*::foundation-model/anthropic.*",
+          "arn:aws:bedrock:*:*:inference-profile/us.anthropic.*"
         ]
       }
     ]


### PR DESCRIPTION
## Summary
- Cross-region inference profiles (`us.anthropic.*`) route requests across multiple US regions internally
- The IAM policy was scoped to `us-east-1` only, causing `AccessDeniedException` when Bedrock routed to `us-east-2`
- Updated docs to use `arn:aws:bedrock:*::foundation-model/anthropic.*` (all regions)
- IAM policy already updated in AWS account

## Test plan
- [x] IAM policy updated in account 557690606827
- [x] Previous run failed with `AccessDeniedException` on `us-east-2` foundation model
- [x] Docs now match actual deployed policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub OIDC IAM policy configuration to enable support for all AWS regions.

* **Chores**
  * Enhanced CI/CD workflow reliability and updated linting configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->