### PR TITLE
feat: split tagging+abuse SCP into two policies

### DIFF
--- a/terraform/scps/README.md
+++ b/terraform/scps/README.md
@@ -7,15 +7,15 @@ to Organizational Units and the organization root.
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | terraform | ~> 1.14 |
 | aws | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| aws | 6.33.0 |
+| ---- | ------- |
+| aws | 6.40.0 |
 
 ## Modules
 
@@ -24,12 +24,14 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
+| [aws_organizations_policy.dev_abuse](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy) | resource |
 | [aws_organizations_policy.dev_scp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy) | resource |
 | [aws_organizations_policy.dev_tagging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy) | resource |
 | [aws_organizations_policy.protect_sso](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy) | resource |
 | [aws_organizations_policy.region_restriction](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy) | resource |
 | [aws_organizations_policy.security_defaults](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy) | resource |
+| [aws_organizations_policy_attachment.dev_abuse_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy_attachment) | resource |
 | [aws_organizations_policy_attachment.dev_scp_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy_attachment) | resource |
 | [aws_organizations_policy_attachment.dev_tagging_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy_attachment) | resource |
 | [aws_organizations_policy_attachment.protect_sso_root](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_policy_attachment) | resource |
@@ -40,14 +42,14 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | aws\_region | AWS region for provider and resources | `string` | `"us-east-1"` | no |
 | dev\_ou\_id | Dev OU ID to attach Dev SCPs to | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | dev\_scp\_arn | Dev SCP Policy ARN |
 | dev\_scp\_id | Dev SCP Policy ID |
 | dev\_tagging\_scp\_arn | Dev Tagging and Abuse Prevention SCP Policy ARN |

--- a/terraform/scps/main.tf
+++ b/terraform/scps/main.tf
@@ -11,16 +11,29 @@ resource "aws_organizations_policy_attachment" "dev_scp_attachment" {
   target_id = var.dev_ou_id
 }
 
-# Dev OU — Required tagging and abuse prevention
+# Dev OU — Required tagging (Team/Name tags)
 resource "aws_organizations_policy" "dev_tagging" {
-  name        = "DevTaggingAndAbusePrevention"
-  description = "Require Team/Name tags and block abusable resources"
+  name        = "DevTaggingEnforcement"
+  description = "Require Team/Name tags on resource creation"
   type        = "SERVICE_CONTROL_POLICY"
-  content     = jsonencode(jsondecode(file("${path.module}/policies/dev-tagging-and-abuse.json")))
+  content     = jsonencode(jsondecode(file("${path.module}/policies/dev-tagging.json")))
 }
 
 resource "aws_organizations_policy_attachment" "dev_tagging_attachment" {
   policy_id = aws_organizations_policy.dev_tagging.id
+  target_id = var.dev_ou_id
+}
+
+# Dev OU — Abuse prevention (costly instances, abusable services)
+resource "aws_organizations_policy" "dev_abuse" {
+  name        = "DevAbusePrevention"
+  description = "Block GPU/metal instances, expensive SageMaker, abusable services, large EBS, public data"
+  type        = "SERVICE_CONTROL_POLICY"
+  content     = file("${path.module}/policies/dev-abuse.json")
+}
+
+resource "aws_organizations_policy_attachment" "dev_abuse_attachment" {
+  policy_id = aws_organizations_policy.dev_abuse.id
   target_id = var.dev_ou_id
 }
 

--- a/terraform/scps/policies/dev-abuse.json
+++ b/terraform/scps/policies/dev-abuse.json
@@ -1,0 +1,110 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyGPUAndMetalInstances",
+      "Effect": "Deny",
+      "Action": [
+        "ec2:RunInstances",
+        "ec2:StartInstances"
+      ],
+      "Resource": "arn:aws:ec2:*:*:instance/*",
+      "Condition": {
+        "StringLike": {
+          "ec2:InstanceType": [
+            "p*",
+            "g*",
+            "inf*",
+            "trn*",
+            "dl*",
+            "*.metal",
+            "*.metal-*"
+          ]
+        },
+        "ArnNotLike": {
+          "aws:PrincipalArn": [
+            "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*AWSReservedSSO_AdministratorAccess_*"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "DenySageMakerExpensiveInstances",
+      "Effect": "Deny",
+      "Action": [
+        "sagemaker:CreateNotebookInstance",
+        "sagemaker:CreateEndpointConfig",
+        "sagemaker:CreateTrainingJob"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringNotLike": {
+          "sagemaker:InstanceType": [
+            "ml.t2.*",
+            "ml.t3.*"
+          ]
+        },
+        "ArnNotLike": {
+          "aws:PrincipalArn": [
+            "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*AWSReservedSSO_AdministratorAccess_*"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "DenyAbusableServices",
+      "Effect": "Deny",
+      "Action": [
+        "lightsail:*",
+        "gamelift:*",
+        "aws-marketplace:Subscribe",
+        "aws-marketplace:AcceptAgreementApprovalRequest"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "ArnNotLike": {
+          "aws:PrincipalArn": [
+            "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*AWSReservedSSO_AdministratorAccess_*"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "DenyLargeEBSVolumes",
+      "Effect": "Deny",
+      "Action": [
+        "ec2:CreateVolume",
+        "ec2:RunInstances"
+      ],
+      "Resource": "arn:aws:ec2:*:*:volume/*",
+      "Condition": {
+        "NumericGreaterThan": {
+          "ec2:VolumeSize": "100"
+        },
+        "ArnNotLike": {
+          "aws:PrincipalArn": [
+            "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*AWSReservedSSO_AdministratorAccess_*"
+          ]
+        }
+      }
+    },
+    {
+      "Sid": "DenyPublicDataExposure",
+      "Effect": "Deny",
+      "Action": [
+        "s3:DeletePublicAccessBlock",
+        "rds:ModifyDBSnapshotAttribute",
+        "rds:ModifyDBClusterSnapshotAttribute",
+        "ec2:ModifySnapshotAttribute"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "ArnNotLike": {
+          "aws:PrincipalArn": [
+            "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*AWSReservedSSO_AdministratorAccess_*"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/terraform/scps/policies/dev-tagging.json
+++ b/terraform/scps/policies/dev-tagging.json
@@ -42,7 +42,9 @@
           "aws:PrincipalArn": [
             "arn:aws:iam::*:role/*AWSReservedSSO_*",
             "arn:aws:iam::*:role/Organization*",
-            "arn:aws:iam::*:role/cleanup-*"
+            "arn:aws:iam::*:role/cleanup-*",
+            "arn:aws:iam::*:role/*-cluster-*",
+            "arn:aws:iam::*:role/*-eks-node-group-*"
           ]
         }
       }
@@ -88,7 +90,9 @@
           "aws:PrincipalArn": [
             "arn:aws:iam::*:role/*AWSReservedSSO_*",
             "arn:aws:iam::*:role/Organization*",
-            "arn:aws:iam::*:role/cleanup-*"
+            "arn:aws:iam::*:role/cleanup-*",
+            "arn:aws:iam::*:role/*-cluster-*",
+            "arn:aws:iam::*:role/*-eks-node-group-*"
           ]
         }
       }
@@ -145,7 +149,9 @@
           "aws:PrincipalArn": [
             "arn:aws:iam::*:role/*AWSReservedSSO_*",
             "arn:aws:iam::*:role/Organization*",
-            "arn:aws:iam::*:role/cleanup-*"
+            "arn:aws:iam::*:role/cleanup-*",
+            "arn:aws:iam::*:role/*-cluster-*",
+            "arn:aws:iam::*:role/*-eks-node-group-*"
           ]
         }
       }
@@ -194,86 +200,12 @@
           "aws:PrincipalArn": [
             "arn:aws:iam::*:role/*AWSReservedSSO_*",
             "arn:aws:iam::*:role/Organization*",
-            "arn:aws:iam::*:role/cleanup-*"
+            "arn:aws:iam::*:role/cleanup-*",
+            "arn:aws:iam::*:role/*-cluster-*",
+            "arn:aws:iam::*:role/*-eks-node-group-*"
           ]
         }
       }
-    },
-    {
-      "Sid": "DenyGPUAndMetalInstances",
-      "Effect": "Deny",
-      "Action": [
-        "ec2:RunInstances",
-        "ec2:StartInstances"
-      ],
-      "Resource": "arn:aws:ec2:*:*:instance/*",
-      "Condition": {
-        "StringLike": {
-          "ec2:InstanceType": [
-            "p*",
-            "g*",
-            "inf*",
-            "trn*",
-            "dl*",
-            "*.metal",
-            "*.metal-*"
-          ]
-        }
-      }
-    },
-    {
-      "Sid": "DenySageMakerExpensiveInstances",
-      "Effect": "Deny",
-      "Action": [
-        "sagemaker:CreateNotebookInstance",
-        "sagemaker:CreateEndpointConfig",
-        "sagemaker:CreateTrainingJob"
-      ],
-      "Resource": "*",
-      "Condition": {
-        "StringNotLike": {
-          "sagemaker:InstanceType": [
-            "ml.t2.*",
-            "ml.t3.*"
-          ]
-        }
-      }
-    },
-    {
-      "Sid": "DenyAbusableServices",
-      "Effect": "Deny",
-      "Action": [
-        "lightsail:*",
-        "gamelift:*",
-        "aws-marketplace:Subscribe",
-        "aws-marketplace:AcceptAgreementApprovalRequest"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Sid": "DenyLargeEBSVolumes",
-      "Effect": "Deny",
-      "Action": [
-        "ec2:CreateVolume",
-        "ec2:RunInstances"
-      ],
-      "Resource": "arn:aws:ec2:*:*:volume/*",
-      "Condition": {
-        "NumericGreaterThan": {
-          "ec2:VolumeSize": "100"
-        }
-      }
-    },
-    {
-      "Sid": "DenyPublicDataExposure",
-      "Effect": "Deny",
-      "Action": [
-        "s3:DeletePublicAccessBlock",
-        "rds:ModifyDBSnapshotAttribute",
-        "rds:ModifyDBClusterSnapshotAttribute",
-        "ec2:ModifySnapshotAttribute"
-      ],
-      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Split `dev-tagging-and-abuse.json` (5,061 chars, near 5,120 limit) into:
- `dev-tagging.json` (4,281 chars) — tag enforcement with EKS role exemptions
- `dev-abuse.json` (1,782 chars) — abuse prevention with admin bypass

## Why

EKS cluster roles need to create security groups and load balancers but were blocked by the tagging SCP. The combined policy had no room for exemptions (59 chars headroom). Splitting into two policies provides room for proper exemptions in both.

## Changes

- Add EKS role exemptions (`*-cluster-*`, `*-eks-node-group-*`) to tagging statements
- Add admin bypass to all abuse prevention statements
- Update main.tf to use two separate policy resources
- Dev OU: 5/5 SCPs (dev-restrictions, dev-tagging, dev-abuse, security-defaults, FullAWSAccess)

## Test plan

- [ ] Terraform plan shows old policy destroyed, 2 new policies created
- [ ] EKS cluster roles can create security groups and load balancers
- [ ] Students still required to tag resources with Team/Name
- [ ] Students still blocked from GPU/metal/expensive instances

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated AWS provider version to 6.40.0.
  * Separated tagging enforcement and abuse prevention controls into dedicated policies for improved clarity and management.

* **New Features**
  * Added comprehensive abuse prevention policy with restrictions on GPU instances, SageMaker operations, Lightsail, GameLift, Marketplace, large EBS volumes, and public access modifications.
  * Extended tagging policy conditions to support additional role patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->