### PR TITLE
fix: update tests and outputs for SCP split

### DIFF
--- a/terraform/scps/README.md
+++ b/terraform/scps/README.md
@@ -50,10 +50,12 @@ No modules.
 
 | Name | Description |
 | ---- | ----------- |
+| dev\_abuse\_scp\_arn | Dev Abuse Prevention SCP Policy ARN |
+| dev\_abuse\_scp\_id | Dev Abuse Prevention SCP Policy ID |
 | dev\_scp\_arn | Dev SCP Policy ARN |
 | dev\_scp\_id | Dev SCP Policy ID |
-| dev\_tagging\_scp\_arn | Dev Tagging and Abuse Prevention SCP Policy ARN |
-| dev\_tagging\_scp\_id | Dev Tagging and Abuse Prevention SCP Policy ID |
+| dev\_tagging\_scp\_arn | Dev Tagging Enforcement SCP Policy ARN |
+| dev\_tagging\_scp\_id | Dev Tagging Enforcement SCP Policy ID |
 | organization\_id | AWS Organization ID |
 | region\_restriction\_scp\_arn | Region Restriction SCP Policy ARN |
 | region\_restriction\_scp\_id | Region Restriction SCP Policy ID |

--- a/terraform/scps/outputs.tf
+++ b/terraform/scps/outputs.tf
@@ -29,13 +29,23 @@ output "sso_protection_scp_arn" {
 }
 
 output "dev_tagging_scp_id" {
-  description = "Dev Tagging and Abuse Prevention SCP Policy ID"
+  description = "Dev Tagging Enforcement SCP Policy ID"
   value       = aws_organizations_policy.dev_tagging.id
 }
 
 output "dev_tagging_scp_arn" {
-  description = "Dev Tagging and Abuse Prevention SCP Policy ARN"
+  description = "Dev Tagging Enforcement SCP Policy ARN"
   value       = aws_organizations_policy.dev_tagging.arn
+}
+
+output "dev_abuse_scp_id" {
+  description = "Dev Abuse Prevention SCP Policy ID"
+  value       = aws_organizations_policy.dev_abuse.id
+}
+
+output "dev_abuse_scp_arn" {
+  description = "Dev Abuse Prevention SCP Policy ARN"
+  value       = aws_organizations_policy.dev_abuse.arn
 }
 
 output "security_defaults_scp_id" {

--- a/tests/scps_test.go
+++ b/tests/scps_test.go
@@ -24,7 +24,8 @@ func allSCPs() []scpInfo {
 	return []scpInfo{
 		{idOutput: "dev_scp_id", arnOutput: "dev_scp_arn", policyName: "DevEnvironmentRestrictions"},
 		{idOutput: "sso_protection_scp_id", arnOutput: "sso_protection_scp_arn", policyName: "ProtectSSOTrustedAccess"},
-		{idOutput: "dev_tagging_scp_id", arnOutput: "dev_tagging_scp_arn", policyName: "DevTaggingAndAbusePrevention"},
+		{idOutput: "dev_tagging_scp_id", arnOutput: "dev_tagging_scp_arn", policyName: "DevTaggingEnforcement"},
+		{idOutput: "dev_abuse_scp_id", arnOutput: "dev_abuse_scp_arn", policyName: "DevAbusePrevention"},
 		{idOutput: "security_defaults_scp_id", arnOutput: "security_defaults_scp_arn", policyName: "SecurityDefaults"},
 		{idOutput: "region_restriction_scp_id", arnOutput: "region_restriction_scp_arn", policyName: "RegionRestriction"},
 	}


### PR DESCRIPTION
## Summary

Follow-up to PR #98. Update integration tests and Terraform outputs to match the new split SCP structure.

- Test: expect `DevTaggingEnforcement` + `DevAbusePrevention` instead of `DevTaggingAndAbusePrevention`
- Outputs: add `dev_abuse_scp_id` and `dev_abuse_scp_arn`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new Terraform outputs: `dev_abuse_scp_id` and `dev_abuse_scp_arn` for accessing abuse prevention policy details.

* **Documentation**
  * Updated Terraform module outputs documentation and descriptions for clarity around tagging enforcement and abuse prevention policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->